### PR TITLE
Update ranking and add new devices

### DIFF
--- a/items.json
+++ b/items.json
@@ -6438,8 +6438,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 21,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceMobile",
@@ -6481,8 +6481,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 21,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",

--- a/items.json
+++ b/items.json
@@ -1199,8 +1199,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 44,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceTablet",

--- a/items.json
+++ b/items.json
@@ -210,8 +210,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 68,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceTablet",
@@ -253,8 +253,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 67,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 23
             },
             "icons": [
                 "deviceTablet",
@@ -296,8 +296,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 66,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 18
             },
             "icons": [
                 "deviceTablet",
@@ -339,8 +339,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 65,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 14
             },
             "icons": [
                 "deviceTablet",
@@ -382,8 +382,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 64,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceTablet",
@@ -425,8 +425,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 63,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceTablet",
@@ -468,8 +468,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 62,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceTablet",
@@ -511,8 +511,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 61,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceTablet",
@@ -554,8 +554,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 60,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 21
             },
             "icons": [
                 "deviceTablet",
@@ -597,8 +597,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 59,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 20
             },
             "icons": [
                 "deviceTablet",
@@ -640,8 +640,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 58,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 16
             },
             "icons": [
                 "deviceTablet",
@@ -683,8 +683,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 57,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 17
             },
             "icons": [
                 "deviceTablet",
@@ -726,8 +726,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 56,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceTablet",
@@ -769,8 +769,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 55,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceTablet",
@@ -898,8 +898,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 52,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceTablet",
@@ -941,8 +941,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 51,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceTablet",
@@ -984,8 +984,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 50,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 22
             },
             "icons": [
                 "deviceTablet",
@@ -1027,8 +1027,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 49,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 15
             },
             "icons": [
                 "deviceTablet",
@@ -1113,8 +1113,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 47,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 19
             },
             "icons": [
                 "deviceTablet",
@@ -1156,8 +1156,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 46,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceTablet",

--- a/items.json
+++ b/items.json
@@ -12,7 +12,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 20,
                 "amongBrand": 13
             },
             "icons": [
@@ -51,7 +51,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 19,
                 "amongBrand": 12
             },
             "icons": [
@@ -90,7 +90,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 18,
                 "amongBrand": 11
             },
             "icons": [
@@ -129,7 +129,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 17,
                 "amongBrand": 10
             },
             "icons": [
@@ -168,7 +168,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 16,
                 "amongBrand": 9
             },
             "icons": [
@@ -3228,7 +3228,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 15,
                 "amongBrand": 17
             },
             "icons": [
@@ -3271,7 +3271,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 14,
                 "amongBrand": 16
             },
             "icons": [
@@ -3314,7 +3314,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 13,
                 "amongBrand": 18
             },
             "icons": [
@@ -3357,7 +3357,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 12,
                 "amongBrand": 19
             },
             "icons": [
@@ -4776,7 +4776,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 8,
                 "amongBrand": 12
             },
             "icons": [
@@ -4820,7 +4820,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 7,
                 "amongBrand": 13
             },
             "icons": [
@@ -5656,7 +5656,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 11,
                 "amongBrand": 13
             },
             "icons": [
@@ -5699,7 +5699,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 10,
                 "amongBrand": 12
             },
             "icons": [
@@ -5742,7 +5742,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 9,
                 "amongBrand": 14
             },
             "icons": [
@@ -7118,7 +7118,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 4,
                 "amongBrand": 14
             },
             "icons": [
@@ -7161,7 +7161,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 5,
                 "amongBrand": 15
             },
             "icons": [
@@ -7204,7 +7204,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 6,
                 "amongBrand": 13
             },
             "icons": [
@@ -7247,7 +7247,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 1,
                 "amongBrand": 3
             },
             "icons": [
@@ -7290,7 +7290,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 2,
                 "amongBrand": 2
             },
             "icons": [
@@ -7333,7 +7333,7 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 0,
+                "amongAll": 3,
                 "amongBrand": 1
             },
             "icons": [

--- a/items.json
+++ b/items.json
@@ -2963,6 +2963,46 @@
         }
     },
     {
+        "id": "id:item:v2024.10.01:matebook-d16",
+        "slug": "matebook-d16",
+        "active": true,
+        "labels": {
+            "primary": "MateBook D16",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "desktop",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 1
+            },
+            "icons": [
+                "deviceDesktop"
+            ],
+            "width": 1352,
+            "height": 845
+        },
+        "properties": {
+            "screen": {
+                "width": 1920,
+                "height": 1200
+            },
+            "viewport": {
+                "width": 1352,
+                "height": 845
+            },
+            "releaseDate": "2022-05-23",
+            "discontinuedDate": null,
+            "devicePixelRatio": 1.42,
+            "operatingSystem": "Windows",
+            "deviceType": "desktop",
+            "brand": "Huawei"
+        }
+    },
+    {
         "id": "id:item:v2024.10.01:iphone-16",
         "slug": "iphone-16",
         "active": true,

--- a/items.json
+++ b/items.json
@@ -2978,8 +2978,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 44,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 17
             },
             "icons": [
                 "deviceMobile",
@@ -3021,8 +3021,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 44,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 16
             },
             "icons": [
                 "deviceMobile",
@@ -3064,8 +3064,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 44,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 18
             },
             "icons": [
                 "deviceMobile",
@@ -3107,8 +3107,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 44,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 19
             },
             "icons": [
                 "deviceMobile",
@@ -3150,8 +3150,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 43,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 35
             },
             "icons": [
                 "deviceMobile",
@@ -3193,8 +3193,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 40,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 15
             },
             "icons": [
                 "deviceMobile",
@@ -3236,8 +3236,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 41,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 32
             },
             "icons": [
                 "deviceMobile",
@@ -3279,8 +3279,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 42,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 36
             },
             "icons": [
                 "deviceMobile",
@@ -3322,8 +3322,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 39,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 31
             },
             "icons": [
                 "deviceMobile",
@@ -3365,8 +3365,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 36,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 25
             },
             "icons": [
                 "deviceMobile",
@@ -3408,8 +3408,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 37,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 33
             },
             "icons": [
                 "deviceMobile",
@@ -3451,8 +3451,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 38,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 34
             },
             "icons": [
                 "deviceMobile",
@@ -3494,8 +3494,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 29
             },
             "icons": [
                 "deviceMobile",
@@ -3537,8 +3537,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 22
             },
             "icons": [
                 "deviceMobile",
@@ -3580,8 +3580,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 35,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 30
             },
             "icons": [
                 "deviceMobile",
@@ -3623,8 +3623,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 33,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 26
             },
             "icons": [
                 "deviceMobile",
@@ -3666,8 +3666,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 34,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 28
             },
             "icons": [
                 "deviceMobile",
@@ -3709,8 +3709,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 14
             },
             "icons": [
                 "deviceMobile",
@@ -3752,8 +3752,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 23
             },
             "icons": [
                 "deviceMobile",
@@ -3795,8 +3795,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceMobile",
@@ -3838,8 +3838,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 24
             },
             "icons": [
                 "deviceMobile",
@@ -3881,8 +3881,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceMobile",
@@ -3924,8 +3924,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 20
             },
             "icons": [
                 "deviceMobile",
@@ -3967,8 +3967,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 21
             },
             "icons": [
                 "deviceMobile",
@@ -4010,8 +4010,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceMobile",
@@ -4053,8 +4053,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceMobile",
@@ -4096,8 +4096,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 27
             },
             "icons": [
                 "deviceMobile",
@@ -4139,8 +4139,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceMobile",
@@ -4182,8 +4182,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceMobile",
@@ -4225,8 +4225,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceMobile",
@@ -4268,8 +4268,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceMobile",
@@ -4311,8 +4311,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceMobile",
@@ -4354,8 +4354,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceMobile",
@@ -4397,8 +4397,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceMobile",
@@ -4440,8 +4440,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceMobile",
@@ -4483,8 +4483,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 32,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",

--- a/items.json
+++ b/items.json
@@ -6509,6 +6509,92 @@
         }
     },
     {
+        "id": "id:item:v2024.10.01:oneplus-ace-3-pro",
+        "slug": "oneplus-ace-3-pro",
+        "active": true,
+        "labels": {
+            "primary": "OnePlus Ace 3 Pro",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "oneplus",
+            "mobile"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 2
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 422,
+            "height": 927
+        },
+        "properties": {
+            "screen": {
+                "width": 1264,
+                "height": 2780
+            },
+            "viewport": {
+                "width": 422,
+                "height": 927
+            },
+            "releaseDate": "2024-07-03",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.0,
+            "operatingSystem": "Android",
+            "deviceType": "phone",
+            "brand": "OnePlus"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:oneplus-ace-3v",
+        "slug": "oneplus-ace-3v",
+        "active": true,
+        "labels": {
+            "primary": "OnePlus Ace 3V",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "oneplus",
+            "mobile"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 3
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 414,
+            "height": 924
+        },
+        "properties": {
+            "screen": {
+                "width": 1240,
+                "height": 2772
+            },
+            "viewport": {
+                "width": 414,
+                "height": 924
+            },
+            "releaseDate": "2024-03-25",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.0,
+            "operatingSystem": "Android",
+            "deviceType": "phone",
+            "brand": "OnePlus"
+        }
+    },
+    {
         "id": "id:item:v2024.10.01:oneplus-5t",
         "slug": "oneplus-5t",
         "active": true,
@@ -6524,8 +6610,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 20,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",

--- a/items.json
+++ b/items.json
@@ -1227,6 +1227,216 @@
         }
     },
     {
+        "id": "id:item:v2024.10.01:matepad-pro-13-2",
+        "slug": "matepad-pro-13-2",
+        "active": true,
+        "labels": {
+            "primary": "MatePad Pro 13.2\"",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "tablet",
+            "touch",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 3
+            },
+            "icons": [
+                "deviceTablet"
+            ],
+            "width": 960,
+            "height": 1440
+        },
+        "properties": {
+            "screen": {
+                "width": 1920,
+                "height": 2880
+            },
+            "viewport": {
+                "width": 960,
+                "height": 1440
+            },
+            "releaseDate": "2023-09-26",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.0,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "tablet",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:matepad-pro-11",
+        "slug": "matepad-pro-11",
+        "active": true,
+        "labels": {
+            "primary": "MatePad Pro 11\"",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "tablet",
+            "touch",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 5
+            },
+            "icons": [
+                "deviceTablet"
+            ],
+            "width": 640,
+            "height": 1024
+        },
+        "properties": {
+            "screen": {
+                "width": 1600,
+                "height": 2560
+            },
+            "viewport": {
+                "width": 640,
+                "height": 1024
+            },
+            "releaseDate": "2023-12-18",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.5,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "tablet",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:matepad-11-5-s",
+        "slug": "matepad-11-5-s",
+        "active": true,
+        "labels": {
+            "primary": "MatePad 11.5\" S",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "tablet",
+            "touch",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 2
+            },
+            "icons": [
+                "deviceTablet"
+            ],
+            "width": 736,
+            "height": 1120
+        },
+        "properties": {
+            "screen": {
+                "width": 1840,
+                "height": 2800
+            },
+            "viewport": {
+                "width": 736,
+                "height": 1120
+            },
+            "releaseDate": "2024-05-08",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.5,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "tablet",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:matepad-air",
+        "slug": "matepad-air",
+        "active": true,
+        "labels": {
+            "primary": "MatePad Air",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "tablet",
+            "touch",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 1
+            },
+            "icons": [
+                "deviceTablet"
+            ],
+            "width": 818,
+            "height": 1245
+        },
+        "properties": {
+            "screen": {
+                "width": 1840,
+                "height": 2800
+            },
+            "viewport": {
+                "width": 818,
+                "height": 1245
+            },
+            "releaseDate": "2024-08-13",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.25,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "tablet",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:matepad-pro-12-2",
+        "slug": "matepad-pro-12-2",
+        "active": true,
+        "labels": {
+            "primary": "MatePad Pro 12.2\"",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "tablet",
+            "touch",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 4
+            },
+            "icons": [
+                "deviceTablet"
+            ],
+            "width": 818,
+            "height": 1245
+        },
+        "properties": {
+            "screen": {
+                "width": 1840,
+                "height": 2800
+            },
+            "viewport": {
+                "width": 818,
+                "height": 1245
+            },
+            "releaseDate": "2024-08-13",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.25,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "tablet",
+            "brand": "Huawei"
+        }
+    },
+    {
         "id": "id:item:v2024.10.01:desktop-hidpi-xl",
         "slug": "desktop-hidpi-xl",
         "active": true,

--- a/items.json
+++ b/items.json
@@ -4526,8 +4526,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceMobile",
@@ -4570,8 +4570,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceMobile",
@@ -4614,8 +4614,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 14
             },
             "icons": [
                 "deviceMobile",
@@ -4658,8 +4658,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 15
             },
             "icons": [
                 "deviceMobile",
@@ -4702,8 +4702,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 19
             },
             "icons": [
                 "deviceMobile",
@@ -4746,8 +4746,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 20
             },
             "icons": [
                 "deviceMobile",
@@ -4790,8 +4790,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 16
             },
             "icons": [
                 "deviceMobile",
@@ -4834,8 +4834,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 17
             },
             "icons": [
                 "deviceMobile",
@@ -4878,8 +4878,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 18
             },
             "icons": [
                 "deviceMobile",
@@ -4922,8 +4922,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceMobile",
@@ -4966,8 +4966,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceMobile",
@@ -5010,8 +5010,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceMobile",
@@ -5054,8 +5054,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceMobile",
@@ -5098,8 +5098,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceMobile",
@@ -5142,8 +5142,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceMobile",
@@ -5186,8 +5186,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceMobile",
@@ -5230,8 +5230,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceMobile",
@@ -5274,8 +5274,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceMobile",
@@ -5318,8 +5318,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",
@@ -5362,8 +5362,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 22,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceMobile",

--- a/items.json
+++ b/items.json
@@ -12,8 +12,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 1,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceDesktop"
@@ -51,8 +51,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 2,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceDesktop"
@@ -90,8 +90,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 3,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceDesktop"
@@ -129,8 +129,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 4,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceDesktop"
@@ -168,8 +168,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 5,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceDesktop"
@@ -1239,8 +1239,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 95,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceDesktop"
@@ -1278,8 +1278,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 100,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceDesktop"
@@ -1317,8 +1317,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 96,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceDesktop"
@@ -1356,8 +1356,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 94,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceDesktop"
@@ -1395,8 +1395,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 98,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceDesktop"
@@ -1434,8 +1434,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 99,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceDesktop"
@@ -1473,8 +1473,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 93,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceDesktop"
@@ -1512,8 +1512,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 97,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceDesktop"

--- a/items.json
+++ b/items.json
@@ -5406,8 +5406,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 31,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceMobile",
@@ -5449,8 +5449,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 31,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceMobile",
@@ -5492,8 +5492,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 31,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 14
             },
             "icons": [
                 "deviceMobile",
@@ -5535,8 +5535,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 30,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 23
             },
             "icons": [
                 "deviceMobile",
@@ -5578,8 +5578,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 22
             },
             "icons": [
                 "deviceMobile",
@@ -5621,8 +5621,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 31,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 24
             },
             "icons": [
                 "deviceMobile",
@@ -5664,8 +5664,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 20
             },
             "icons": [
                 "deviceMobile",
@@ -5707,8 +5707,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 19
             },
             "icons": [
                 "deviceMobile",
@@ -5750,8 +5750,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 29,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 21
             },
             "icons": [
                 "deviceMobile",
@@ -5793,8 +5793,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 17
             },
             "icons": [
                 "deviceMobile",
@@ -5836,8 +5836,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 16
             },
             "icons": [
                 "deviceMobile",
@@ -5879,8 +5879,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 18
             },
             "icons": [
                 "deviceMobile",
@@ -5922,8 +5922,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceMobile",
@@ -5965,8 +5965,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceMobile",
@@ -6008,8 +6008,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceMobile",
@@ -6051,8 +6051,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceMobile",
@@ -6094,8 +6094,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceMobile",
@@ -6137,8 +6137,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceMobile",
@@ -6180,8 +6180,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceMobile",
@@ -6223,8 +6223,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceMobile",
@@ -6266,8 +6266,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",
@@ -6309,8 +6309,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceMobile",
@@ -6352,8 +6352,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 23,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 15
             },
             "icons": [
                 "deviceMobile",
@@ -6395,8 +6395,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 24,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceMobile",

--- a/items.json
+++ b/items.json
@@ -797,11 +797,11 @@
         }
     },
     {
-        "id": "id:item:v2024.10.01:ipad-pro-12-9-3th-gen-2018",
-        "slug": "ipad-pro-12-9-3th-gen-2018",
+        "id": "id:item:v2024.10.01:ipad-pro-12-9-3rd-gen-2018",
+        "slug": "ipad-pro-12-9-3rd-gen-2018",
         "active": true,
         "labels": {
-            "primary": "iPad Pro 12.9\" (3th gen, 2018)",
+            "primary": "iPad Pro 12.9\" (3rd gen, 2018)",
             "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
         },
         "tags": [
@@ -812,8 +812,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 54,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceTablet",
@@ -840,11 +840,11 @@
         }
     },
     {
-        "id": "id:item:v2024.10.01:ipad-pro-11-3th-gen-2018",
-        "slug": "ipad-pro-11-3th-gen-2018",
+        "id": "id:item:v2024.10.01:ipad-pro-11-3rd-gen-2018",
+        "slug": "ipad-pro-11-3rd-gen-2018",
         "active": true,
         "labels": {
-            "primary": "iPad Pro 11\" (3th gen, 2018)",
+            "primary": "iPad Pro 11\" (3rd gen, 2018)",
             "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
         },
         "tags": [
@@ -855,8 +855,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 53,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceTablet",
@@ -1055,11 +1055,11 @@
         }
     },
     {
-        "id": "id:item:v2024.10.01:ipad-air-3th-gen-2019",
-        "slug": "ipad-air-3th-gen-2019",
+        "id": "id:item:v2024.10.01:ipad-air-3rd-gen-2019",
+        "slug": "ipad-air-3rd-gen-2019",
         "active": true,
         "labels": {
-            "primary": "iPad Air (3th gen, 2019)",
+            "primary": "iPad Air (3rd gen, 2019)",
             "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
         },
         "tags": [
@@ -1070,8 +1070,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 48,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceTablet",

--- a/items.json
+++ b/items.json
@@ -2537,7 +2537,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 3
             },
             "icons": [
                 "deviceDesktop"
@@ -2577,7 +2577,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 2
             },
             "icons": [
                 "deviceDesktop"
@@ -2617,7 +2617,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 1
             },
             "icons": [
                 "deviceDesktop"
@@ -2657,7 +2657,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 7
             },
             "icons": [
                 "deviceDesktop"
@@ -2697,7 +2697,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 11
             },
             "icons": [
                 "deviceDesktop"
@@ -2737,7 +2737,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 10
             },
             "icons": [
                 "deviceDesktop"
@@ -2777,7 +2777,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 9
             },
             "icons": [
                 "deviceDesktop"
@@ -2817,7 +2817,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 8
             },
             "icons": [
                 "deviceDesktop"
@@ -2857,7 +2857,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 4
             },
             "icons": [
                 "deviceDesktop"
@@ -2897,7 +2897,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 6
             },
             "icons": [
                 "deviceDesktop"
@@ -2937,7 +2937,7 @@
         "attributes": {
             "ranking": {
                 "amongAll": 0,
-                "amongBrand": 0
+                "amongBrand": 5
             },
             "icons": [
                 "deviceDesktop"

--- a/items.json
+++ b/items.json
@@ -1552,8 +1552,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 92,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 11
             },
             "icons": [
                 "deviceDesktop",
@@ -1593,8 +1593,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 91,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceDesktop",
@@ -1634,8 +1634,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 90,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 16
             },
             "icons": [
                 "deviceDesktop",
@@ -1675,8 +1675,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 89,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 15
             },
             "icons": [
                 "deviceDesktop",
@@ -1716,8 +1716,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 88,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 10
             },
             "icons": [
                 "deviceDesktop",
@@ -1757,8 +1757,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 87,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 14
             },
             "icons": [
                 "deviceDesktop",
@@ -1798,8 +1798,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 86,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 13
             },
             "icons": [
                 "deviceDesktop",
@@ -1839,8 +1839,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 85,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 20
             },
             "icons": [
                 "deviceDesktop",
@@ -1880,8 +1880,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 84,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 21
             },
             "icons": [
                 "deviceDesktop",
@@ -1921,8 +1921,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 83,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 17
             },
             "icons": [
                 "deviceDesktop",
@@ -1962,8 +1962,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 82,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 19
             },
             "icons": [
                 "deviceDesktop",
@@ -2003,8 +2003,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 81,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 18
             },
             "icons": [
                 "deviceDesktop",
@@ -2044,8 +2044,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 80,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceDesktop",
@@ -2085,8 +2085,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 79,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceDesktop",
@@ -2126,8 +2126,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 78,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 23
             },
             "icons": [
                 "deviceDesktop",
@@ -2167,8 +2167,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 77,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 24
             },
             "icons": [
                 "deviceDesktop",
@@ -2208,8 +2208,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 76,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 7
             },
             "icons": [
                 "deviceDesktop",
@@ -2249,8 +2249,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 75,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceDesktop",
@@ -2290,8 +2290,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 74,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceDesktop",
@@ -2331,8 +2331,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 73,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 6
             },
             "icons": [
                 "deviceDesktop",
@@ -2372,8 +2372,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 72,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceDesktop",
@@ -2413,8 +2413,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 71,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 8
             },
             "icons": [
                 "deviceDesktop",
@@ -2454,8 +2454,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 70,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 22
             },
             "icons": [
                 "deviceDesktop",
@@ -2495,8 +2495,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 69,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 5
             },
             "icons": [
                 "deviceDesktop",

--- a/items.json
+++ b/items.json
@@ -6903,8 +6903,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 19,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 12
             },
             "icons": [
                 "deviceMobile",
@@ -6946,8 +6946,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 19,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 9
             },
             "icons": [
                 "deviceMobile",
@@ -6989,8 +6989,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 19,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 4
             },
             "icons": [
                 "deviceMobile",
@@ -7011,6 +7011,522 @@
             "releaseDate": "2020-04-22",
             "discontinuedDate": null,
             "devicePixelRatio": 3.0,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:mate-x5",
+        "slug": "mate-x5",
+        "active": true,
+        "labels": {
+            "primary": "Mate X5",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 11
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 659,
+            "height": 740
+        },
+        "properties": {
+            "screen": {
+                "width": 2224,
+                "height": 2496
+            },
+            "viewport": {
+                "width": 659,
+                "height": 740
+            },
+            "releaseDate": "2023-09-16",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.375,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:pocket-2",
+        "slug": "pocket-2",
+        "active": true,
+        "labels": {
+            "primary": "Pocket 2",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 6
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 364,
+            "height": 861
+        },
+        "properties": {
+            "screen": {
+                "width": 1136,
+                "height": 2690
+            },
+            "viewport": {
+                "width": 364,
+                "height": 861
+            },
+            "releaseDate": "2024-02-22",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.125,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:mate-60-pro-plus",
+        "slug": "mate-60-pro-plus",
+        "active": true,
+        "labels": {
+            "primary": "Mate 60 Pro Plus",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 14
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 388,
+            "height": 837
+        },
+        "properties": {
+            "screen": {
+                "width": 1260,
+                "height": 2720
+            },
+            "viewport": {
+                "width": 388,
+                "height": 837
+            },
+            "releaseDate": "2023-09-27",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.25,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:mate-60-pro",
+        "slug": "mate-60-pro",
+        "active": true,
+        "labels": {
+            "primary": "Mate 60 Pro",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 15
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 388,
+            "height": 837
+        },
+        "properties": {
+            "screen": {
+                "width": 1260,
+                "height": 2720
+            },
+            "viewport": {
+                "width": 388,
+                "height": 837
+            },
+            "releaseDate": "2023-08-29",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.25,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:mate-60",
+        "slug": "mate-60",
+        "active": true,
+        "labels": {
+            "primary": "Mate 60",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 13
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 375,
+            "height": 827
+        },
+        "properties": {
+            "screen": {
+                "width": 1216,
+                "height": 2688
+            },
+            "viewport": {
+                "width": 375,
+                "height": 827
+            },
+            "releaseDate": "2023-09-10",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.25,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:pura-70-pro-plus",
+        "slug": "pura-70-pro-plus",
+        "active": true,
+        "labels": {
+            "primary": "Pura 70 Pro Plus",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 3
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 374,
+            "height": 843
+        },
+        "properties": {
+            "screen": {
+                "width": 1260,
+                "height": 2844
+            },
+            "viewport": {
+                "width": 374,
+                "height": 843
+            },
+            "releaseDate": "2024-04-29",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.375,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:pura-70-pro",
+        "slug": "pura-70-pro",
+        "active": true,
+        "labels": {
+            "primary": "Pura 70 Pro",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 2
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 374,
+            "height": 843
+        },
+        "properties": {
+            "screen": {
+                "width": 1260,
+                "height": 2844
+            },
+            "viewport": {
+                "width": 374,
+                "height": 843
+            },
+            "releaseDate": "2024-04-29",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.375,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:pura-70",
+        "slug": "pura-70",
+        "active": true,
+        "labels": {
+            "primary": "Pura 70",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 1
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 373,
+            "height": 818
+        },
+        "properties": {
+            "screen": {
+                "width": 1256,
+                "height": 2760
+            },
+            "viewport": {
+                "width": 373,
+                "height": 818
+            },
+            "releaseDate": "2024-05-06",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.375,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:pura-70-ultra",
+        "slug": "pura-70-ultra",
+        "active": true,
+        "labels": {
+            "primary": "Pura 70 Ultra",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 5
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 374,
+            "height": 843
+        },
+        "properties": {
+            "screen": {
+                "width": 1260,
+                "height": 2844
+            },
+            "viewport": {
+                "width": 374,
+                "height": 843
+            },
+            "releaseDate": "2024-04-29",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.375,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:nova-flip",
+        "slug": "nova-flip",
+        "active": true,
+        "labels": {
+            "primary": "nova Flip",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 10
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 364,
+            "height": 861
+        },
+        "properties": {
+            "screen": {
+                "width": 1136,
+                "height": 2690
+            },
+            "viewport": {
+                "width": 364,
+                "height": 861
+            },
+            "releaseDate": "2024-08-10",
+            "discontinuedDate": null,
+            "devicePixelRatio": 3.125,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:nova-12-ultra",
+        "slug": "nova-12-ultra",
+        "active": true,
+        "labels": {
+            "primary": "nova 12 Ultra",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 8
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 414,
+            "height": 939
+        },
+        "properties": {
+            "screen": {
+                "width": 1224,
+                "height": 2776
+            },
+            "viewport": {
+                "width": 414,
+                "height": 939
+            },
+            "releaseDate": "2024-01-12",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.956,
+            "operatingSystem": "HarmonyOS",
+            "deviceType": "phone",
+            "brand": "Huawei"
+        }
+    },
+    {
+        "id": "id:item:v2024.10.01:nova-12-pro",
+        "slug": "nova-12-pro",
+        "active": true,
+        "labels": {
+            "primary": "nova 12 Pro",
+            "secondary": "{{item.attributes.width}}x{{item.attributes.height}}"
+        },
+        "tags": [
+            "touch",
+            "phone",
+            "mobile",
+            "huawei"
+        ],
+        "attributes": {
+            "ranking": {
+                "amongAll": 0,
+                "amongBrand": 7
+            },
+            "icons": [
+                "deviceMobile",
+                "brandAndroid"
+            ],
+            "width": 414,
+            "height": 939
+        },
+        "properties": {
+            "screen": {
+                "width": 1224,
+                "height": 2776
+            },
+            "viewport": {
+                "width": 414,
+                "height": 939
+            },
+            "releaseDate": "2024-01-05",
+            "discontinuedDate": null,
+            "devicePixelRatio": 2.956,
             "operatingSystem": "HarmonyOS",
             "deviceType": "phone",
             "brand": "Huawei"

--- a/items.json
+++ b/items.json
@@ -6696,8 +6696,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 18,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 1
             },
             "icons": [
                 "deviceMobile",
@@ -6739,8 +6739,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 18,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 2
             },
             "icons": [
                 "deviceMobile",
@@ -6782,8 +6782,8 @@
         ],
         "attributes": {
             "ranking": {
-                "amongAll": 18,
-                "amongBrand": 0
+                "amongAll": 0,
+                "amongBrand": 3
             },
             "icons": [
                 "deviceMobile",


### PR DESCRIPTION
- Added 2 OnePlus phones
- Added 12 Huawei phones
- Added 1 Huawei desktop
- Added 5 Huawei tablets
- Assigned `amongBrand` for all devices within their device type + brand group (use it DESC)
- Assigned `amongAll` for selected 20 devices (use it DESC)
```
[
  "Desktop #1",
  "Desktop #2",
  "Desktop #3",
  "Desktop #4",
  "Desktop #5",
  "iPhone 16",
  "iPhone 16 Plus",
  "iPhone 16 Pro",
  "iPhone 16 Pro Max",
  "Galaxy S24",
  "Galaxy S24 Plus",
  "Galaxy S24 Ultra",
  "Google Pixel 9",
  "Google Pixel 9 Pro XL",
  "Mate 60",
  "Mate 60 Pro",
  "Mate 60 Pro Plus",
  "Pura 70",
  "Pura 70 Pro",
  "Pura 70 Pro Plus"
]
```